### PR TITLE
Add new and updated appdata.xml file to Flatpak manifest

### DIFF
--- a/com.inform7.IDE.yml
+++ b/com.inform7.IDE.yml
@@ -235,7 +235,6 @@ modules:
         sha256: ef68c09c533e60f5e7a29950757a1b229985280ceb960b2f9be77c57629745ba
         dest-filename: updated-appdata.xml
     build-commands:
-      - rm /app/share/appdata/$FLATPAK_ID.appdata.xml
       - install -Dm644 updated-appdata.xml /app/share/appdata/$FLATPAK_ID.appdata.xml
 
 ...

--- a/com.inform7.IDE.yml
+++ b/com.inform7.IDE.yml
@@ -216,7 +216,7 @@ modules:
     post-install:
       - install -Dm644 updated-appdata.xml /app/share/appdata/$FLATPAK_ID.appdata.xml
     sources:
-      # Remove updated-appdata.xml and the post-install commands
+      # Remove updated-appdata.xml and the post-install command
       # when the next version of the Inform IDE gets released
       # and is updated here in this Flatpak manifest
       - type: file

--- a/com.inform7.IDE.yml
+++ b/com.inform7.IDE.yml
@@ -220,7 +220,7 @@ modules:
       # when the next version of the Inform IDE gets released
       # and is updated here in this Flatpak manifest
       - type: file
-        url: https://github.com/ptomato/inform7-ide/blob/fd8ec391f60ba00684cd46cdf82187f97e43d1c1/com.inform7.IDE.appdata.xml
+        url: https://raw.githubusercontent.com/ptomato/inform7-ide/fd8ec391f60ba00684cd46cdf82187f97e43d1c1/com.inform7.IDE.appdata.xml
         sha256: ef68c09c533e60f5e7a29950757a1b229985280ceb960b2f9be77c57629745ba
         dest-filename: updated-appdata.xml
       - type: git

--- a/com.inform7.IDE.yml
+++ b/com.inform7.IDE.yml
@@ -233,7 +233,9 @@ modules:
       - type: file
         url: https://raw.githubusercontent.com/ptomato/inform7-ide/fd8ec391f60ba00684cd46cdf82187f97e43d1c1/com.inform7.IDE.appdata.xml
         sha256: ef68c09c533e60f5e7a29950757a1b229985280ceb960b2f9be77c57629745ba
+        dest-filename: updated-appdata.xml
     build-commands:
-      - install -Dm644 $FLATPAK_ID.appdata.xml /app/share/appdata/$FLATPAK_ID.appdata.xml
+      - rm /app/share/appdata/$FLATPAK_ID.appdata.xml
+      - install -Dm644 updated-appdata.xml /app/share/appdata/$FLATPAK_ID.appdata.xml
 
 ...

--- a/com.inform7.IDE.yml
+++ b/com.inform7.IDE.yml
@@ -213,25 +213,27 @@ modules:
       - cp -R inform/retrospective /app/tmp
   - name: inform7-ide
     buildsystem: meson
-    post-install:
-      - install -Dm644 updated-appdata.xml /app/share/appdata/$FLATPAK_ID.appdata.xml
     sources:
-      # Remove updated-appdata.xml and the post-install command
-      # when the next version of the Inform IDE gets released
-      # and is updated here in this Flatpak manifest
       - type: git
         url: https://github.com/ptomato/inform7-ide.git
         tag: '2.0.0'
         commit: 9c4c0ba7994dafff49b64319e2b1606005ad5d1b
-      - type: file
-        url: https://raw.githubusercontent.com/ptomato/inform7-ide/fd8ec391f60ba00684cd46cdf82187f97e43d1c1/com.inform7.IDE.appdata.xml
-        sha256: ef68c09c533e60f5e7a29950757a1b229985280ceb960b2f9be77c57629745ba
-        dest-filename: updated-appdata.xml
       - type: shell
         commands:
           - cp -R /app/tmp/intools .
           - cp -R /app/tmp/data/* data/
           - cp -R /app/tmp/inform/* src/inform/
           - cp -R /app/tmp/retrospective .
+  # Remove this updated-appdata module when the next
+  # version of the Inform IDE gets released and is
+  # updated here in this Flatpak manifest
+  - name: updated-appdata
+    buildsystem: simple
+    sources:
+      - type: file
+        url: https://raw.githubusercontent.com/ptomato/inform7-ide/fd8ec391f60ba00684cd46cdf82187f97e43d1c1/com.inform7.IDE.appdata.xml
+        sha256: ef68c09c533e60f5e7a29950757a1b229985280ceb960b2f9be77c57629745ba
+    build-commands:
+      - install -Dm644 $FLATPAK_ID.appdata.xml /app/share/appdata/$FLATPAK_ID.appdata.xml
 
 ...

--- a/com.inform7.IDE.yml
+++ b/com.inform7.IDE.yml
@@ -213,7 +213,16 @@ modules:
       - cp -R inform/retrospective /app/tmp
   - name: inform7-ide
     buildsystem: meson
+    post-install:
+      - install -Dm644 updated-appdata.xml /app/share/appdata/$FLATPAK_ID.appdata.xml
     sources:
+      # Remove updated-appdata.xml and the post-install commands
+      # when the next version of the Inform IDE gets released
+      # and is updated here in this Flatpak manifest
+      - type: file
+        url: https://github.com/ptomato/inform7-ide/blob/fd8ec391f60ba00684cd46cdf82187f97e43d1c1/com.inform7.IDE.appdata.xml
+        sha256: ef68c09c533e60f5e7a29950757a1b229985280ceb960b2f9be77c57629745ba
+        dest-filename: updated-appdata.xml
       - type: git
         url: https://github.com/ptomato/inform7-ide.git
         tag: '2.0.0'

--- a/com.inform7.IDE.yml
+++ b/com.inform7.IDE.yml
@@ -219,14 +219,14 @@ modules:
       # Remove updated-appdata.xml and the post-install command
       # when the next version of the Inform IDE gets released
       # and is updated here in this Flatpak manifest
-      - type: file
-        url: https://raw.githubusercontent.com/ptomato/inform7-ide/fd8ec391f60ba00684cd46cdf82187f97e43d1c1/com.inform7.IDE.appdata.xml
-        sha256: ef68c09c533e60f5e7a29950757a1b229985280ceb960b2f9be77c57629745ba
-        dest-filename: updated-appdata.xml
       - type: git
         url: https://github.com/ptomato/inform7-ide.git
         tag: '2.0.0'
         commit: 9c4c0ba7994dafff49b64319e2b1606005ad5d1b
+      - type: file
+        url: https://raw.githubusercontent.com/ptomato/inform7-ide/fd8ec391f60ba00684cd46cdf82187f97e43d1c1/com.inform7.IDE.appdata.xml
+        sha256: ef68c09c533e60f5e7a29950757a1b229985280ceb960b2f9be77c57629745ba
+        dest-filename: updated-appdata.xml
       - type: shell
         commands:
           - cp -R /app/tmp/intools .

--- a/com.inform7.IDE.yml
+++ b/com.inform7.IDE.yml
@@ -235,6 +235,6 @@ modules:
         sha256: ef68c09c533e60f5e7a29950757a1b229985280ceb960b2f9be77c57629745ba
         dest-filename: updated-appdata.xml
     build-commands:
-      - install -Dm644 updated-appdata.xml /app/share/appdata/$FLATPAK_ID.appdata.xml
+      - install -Dm644 updated-appdata.xml /app/share/metainfo/$FLATPAK_ID.appdata.xml
 
 ...


### PR DESCRIPTION
Since I won't know, at least right now, when the next release of the Inform IDE is coming out, I figured it'd be a good idea to include, in this Flatpak, the new appdata.xml file we just pushed to the IDE's source code, in the recently merged PR ptomato/inform7-ide#33.

This is related to #12 as, even though the appdata.xml in the IDE source code is updated _now_, the source files downloaded for this Flatpak (`2.0.0`) still contain the old appdata.xml, and therefore (among other things) the Flathub page will still show the app as being proprietary when it's no longer the case.

This originally derived from a patch file I made for #13, but since the new appdata.xml was pushed recently and, as of now, there are ongoing issues caused after updating the GNOME runtime (and webkit2gtk) in #13, I ultimately decided that the new appdata.xml should get its own PR so that it can hopefully get merged to Flathub as soon as possible.