### PR TITLE
Update manifest to 2.0.2

### DIFF
--- a/com.inform7.IDE.yml
+++ b/com.inform7.IDE.yml
@@ -1,7 +1,7 @@
 ---
 app-id: com.inform7.IDE
 runtime: org.gnome.Platform
-runtime-version: '46'
+runtime-version: '50'
 sdk: org.gnome.Sdk
 finish-args:
   - --socket=x11
@@ -39,6 +39,9 @@ modules:
       - /lib/pkgconfig
       - /share/gtk-doc
       - '*.la'
+    build-options:
+      # Missing GOO_CANVAS_ITEM_MODEL_SIMPLE cast
+      cflags: -Wno-error=incompatible-pointer-types
     config-opts:
       - --disable-introspection
       - --disable-python
@@ -167,8 +170,8 @@ modules:
     sources:
       - type: archive
         url: "https://github.com/chimara/Chimara/releases/download/\
-          0.9.4/chimara-0.9.4.tar.xz"
-        sha256: d2e097649e20f4f78f30c80839368f0017495c18c257052604a9f09bdfd4396f
+          0.9.5/chimara-0.9.5.tar.xz"
+        sha256: 7839d27b0c95d21c2f835e208cdbec13500de5dfe3ad7d8ca0b972087bb95d78
   - name: rsync
     config-opts:
       # rsync is only used to install some of Inform's data files locally.
@@ -187,8 +190,8 @@ modules:
     cleanup: ['*']
     sources:
       - type: archive
-        url: https://download.samba.org/pub/rsync/src/rsync-3.2.3.tar.gz
-        sha256: becc3c504ceea499f4167a260040ccf4d9f2ef9499ad5683c179a697146ce50e
+        url: https://download.samba.org/pub/rsync/rsync-3.4.1.tar.gz
+        sha256: 2924bcb3a1ed8b551fc101f740b9f0fe0a202b115027647cf69850d65fd88c52
   - name: inform
     buildsystem: simple
     cleanup: ['*']
@@ -227,8 +230,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/ptomato/inform7-ide.git
-        tag: 2.0.1
-        commit: ea86b9830a96bc16c2cbd3857f00a8cf07c327f3
+        tag: 2.0.2
+        commit: 4982ceffa0e645721dd0b9364e0157366c0d3379
       - type: shell
         commands:
           - cp -R /app/tmp/intools .


### PR DESCRIPTION
This version of the app works with the newest GNOME runtime.

Supersedes #18, #21